### PR TITLE
Always search starting after/before $CURSOR, not on it.

### DIFF
--- a/src/zsh-vi-search.zsh
+++ b/src/zsh-vi-search.zsh
@@ -28,7 +28,7 @@ function _index-of {
 function _vi-search-forward {
   setopt localoptions no_sh_word_split
   read-from-minibuffer
-  INDEX=$(_index-of $BUFFER $REPLY $CURSOR) && CURSOR=$INDEX || INDEX=$(_index-of $BUFFER $REPLY 0) && CURSOR=$INDEX
+  INDEX=$(_index-of $BUFFER $REPLY $(($CURSOR + 1))) && CURSOR=$INDEX || INDEX=$(_index-of $BUFFER $REPLY 0) && CURSOR=$INDEX
   export VISEARCHSTR=$REPLY
   export VISEARCHDIRECTION=1
 }
@@ -41,7 +41,7 @@ function _vi-search-forward-repeat {
 function _vi-search-backward {
   setopt localoptions no_sh_word_split
   read-from-minibuffer
-  INDEX=$(_index-of $BUFFER $REPLY $CURSOR -1) && CURSOR=$INDEX || INDEX=$(_index-of $BUFFER $REPLY $((${#BUFFER} - 1)) -1) && CURSOR=$INDEX
+  INDEX=$(_index-of $BUFFER $REPLY $(($CURSOR - 1)) -1) && CURSOR=$INDEX || INDEX=$(_index-of $BUFFER $REPLY $((${#BUFFER} - 1)) -1) && CURSOR=$INDEX
   export VISEARCHSTR=$REPLY
   export VISEARCHDIRECTION=-1
 }


### PR DESCRIPTION
Previously it would search starting at $CURSOR the first time, and one
character after/before when executing n/N.  Thus, if you executed "/a"
while the current highlighted character was "a", the cursor would find
the "a" at the current position and not move, but executing "n" would
find other instances later in the line.  Hoever, this does not match the
behavior of (at least) vim, which never searches for a match at the
current position.